### PR TITLE
feat: enable editing and deleting blood tests

### DIFF
--- a/HealthApp/HealthApp/ContentView.swift
+++ b/HealthApp/HealthApp/ContentView.swift
@@ -58,7 +58,7 @@ struct HealthDataView: View {
                 )
                 
                 BloodTestsSection(
-                    bloodTests: healthDataManager.bloodTests,
+                    bloodTests: $healthDataManager.bloodTests,
                     onAddNew: { showingBloodTestEntry = true },
                     onEdit: { editingBloodTest = $0 },
                     onDelete: { bloodTest in

--- a/HealthApp/HealthApp/ContentView.swift
+++ b/HealthApp/HealthApp/ContentView.swift
@@ -47,6 +47,7 @@ struct HealthDataView: View {
     )
     @State private var showingPersonalInfoEditor = false
     @State private var showingBloodTestEntry = false
+    @State private var editingBloodTest: BloodTestResult?
     
     var body: some View {
         NavigationStack {
@@ -58,7 +59,13 @@ struct HealthDataView: View {
                 
                 BloodTestsSection(
                     bloodTests: healthDataManager.bloodTests,
-                    onAddNew: { showingBloodTestEntry = true }
+                    onAddNew: { showingBloodTestEntry = true },
+                    onEdit: { editingBloodTest = $0 },
+                    onDelete: { bloodTest in
+                        Task {
+                            try await healthDataManager.deleteBloodTest(bloodTest)
+                        }
+                    }
                 )
                 
                 // Placeholder sections for future data types
@@ -119,6 +126,13 @@ struct HealthDataView: View {
                         }
                     }
                 )
+            }
+            .sheet(item: $editingBloodTest) { bloodTest in
+                BloodTestEntryView(bloodTest: bloodTest) { updated in
+                    Task {
+                        try await healthDataManager.updateBloodTest(updated)
+                    }
+                }
             }
         }
     }

--- a/HealthApp/HealthApp/Views/BloodTestEntryView.swift
+++ b/HealthApp/HealthApp/Views/BloodTestEntryView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct BloodTestEntryView: View {
+    let bloodTest: BloodTestResult?
     let onSave: (BloodTestResult) -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -17,6 +18,15 @@ struct BloodTestEntryView: View {
 
     // Focus state for keyboard management
     @FocusState private var isAnyFieldFocused: Bool
+
+    init(bloodTest: BloodTestResult? = nil, onSave: @escaping (BloodTestResult) -> Void) {
+        self.bloodTest = bloodTest
+        self.onSave = onSave
+        _testDate = State(initialValue: bloodTest?.testDate ?? Date())
+        _laboratoryName = State(initialValue: bloodTest?.laboratoryName ?? "")
+        _orderingPhysician = State(initialValue: bloodTest?.orderingPhysician ?? "")
+        _results = State(initialValue: bloodTest?.results ?? [])
+    }
 
     var body: some View {
         NavigationStack {
@@ -134,7 +144,7 @@ struct BloodTestEntryView: View {
                     }
                 }
             }
-            .navigationTitle("Blood Test Entry")
+            .navigationTitle(bloodTest == nil ? "Blood Test Entry" : "Edit Blood Test")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -146,10 +156,13 @@ struct BloodTestEntryView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Save") {
                         let bloodTest = BloodTestResult(
+                            id: bloodTest?.id ?? UUID(),
                             testDate: testDate,
                             laboratoryName: laboratoryName.isEmpty ? nil : laboratoryName,
                             orderingPhysician: orderingPhysician.isEmpty ? nil : orderingPhysician,
-                            results: results.filter { !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                            results: results.filter { !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty },
+                            createdAt: bloodTest?.createdAt ?? Date(),
+                            updatedAt: Date()
                         )
                         onSave(bloodTest)
                         dismiss()

--- a/HealthApp/HealthApp/Views/BloodTestsSection.swift
+++ b/HealthApp/HealthApp/Views/BloodTestsSection.swift
@@ -156,9 +156,19 @@ struct EmptyBloodTestsView: View {
 }
 
 struct BloodTestListView: View {
-    let bloodTests: [BloodTestResult]
+    @State private var bloodTests: [BloodTestResult]
     let onEdit: (BloodTestResult) -> Void
     let onDelete: (BloodTestResult) -> Void
+
+    init(
+        bloodTests: [BloodTestResult],
+        onEdit: @escaping (BloodTestResult) -> Void,
+        onDelete: @escaping (BloodTestResult) -> Void
+    ) {
+        _bloodTests = State(initialValue: bloodTests)
+        self.onEdit = onEdit
+        self.onDelete = onDelete
+    }
 
     var body: some View {
         List {
@@ -174,7 +184,9 @@ struct BloodTestListView: View {
                 }
             }
             .onDelete { indexSet in
-                indexSet.map { bloodTests[$0] }.forEach { onDelete($0) }
+                let items = indexSet.map { bloodTests[$0] }
+                items.forEach { onDelete($0) }
+                bloodTests.remove(atOffsets: indexSet)
             }
         }
         .navigationTitle("Blood Test Results")

--- a/HealthApp/HealthApp/Views/BloodTestsSection.swift
+++ b/HealthApp/HealthApp/Views/BloodTestsSection.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct BloodTestsSection: View {
-    let bloodTests: [BloodTestResult]
+    @Binding var bloodTests: [BloodTestResult]
     let onAddNew: () -> Void
     let onEdit: (BloodTestResult) -> Void
     let onDelete: (BloodTestResult) -> Void
@@ -26,7 +26,7 @@ struct BloodTestsSection: View {
                 if bloodTests.count > 3 {
                     NavigationLink("View All (\(bloodTests.count))") {
                         BloodTestListView(
-                            bloodTests: bloodTests,
+                            bloodTests: $bloodTests,
                             onEdit: onEdit,
                             onDelete: onDelete
                         )
@@ -156,19 +156,9 @@ struct EmptyBloodTestsView: View {
 }
 
 struct BloodTestListView: View {
-    @State private var bloodTests: [BloodTestResult]
+    @Binding var bloodTests: [BloodTestResult]
     let onEdit: (BloodTestResult) -> Void
     let onDelete: (BloodTestResult) -> Void
-
-    init(
-        bloodTests: [BloodTestResult],
-        onEdit: @escaping (BloodTestResult) -> Void,
-        onDelete: @escaping (BloodTestResult) -> Void
-    ) {
-        _bloodTests = State(initialValue: bloodTests)
-        self.onEdit = onEdit
-        self.onDelete = onDelete
-    }
 
     var body: some View {
         List {
@@ -300,31 +290,43 @@ struct BloodTestItemRow: View {
     }
 }
 
-#Preview {
-    NavigationStack {
-        List {
-            BloodTestsSection(
-                bloodTests: [
-                    BloodTestResult(
-                        testDate: Date(),
-                        laboratoryName: "LabCorp",
-                        results: [
-                            BloodTestItem(name: "Glucose", value: "110", unit: "mg/dL", referenceRange: "70-100", isAbnormal: true),
-                            BloodTestItem(name: "Cholesterol", value: "180", unit: "mg/dL", referenceRange: "<200")
-                        ]
-                    )
-                ],
-                onAddNew: {},
-                onEdit: { _ in },
-                onDelete: { _ in }
-            )
+struct BloodTestsSection_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            List {
+                PreviewWrapper()
+            }
+        }
+    }
 
-            BloodTestsSection(
-                bloodTests: [],
-                onAddNew: {},
-                onEdit: { _ in },
-                onDelete: { _ in }
+    private struct PreviewWrapper: View {
+        @State private var sampleTests = [
+            BloodTestResult(
+                testDate: Date(),
+                laboratoryName: "LabCorp",
+                results: [
+                    BloodTestItem(name: "Glucose", value: "110", unit: "mg/dL", referenceRange: "70-100", isAbnormal: true),
+                    BloodTestItem(name: "Cholesterol", value: "180", unit: "mg/dL", referenceRange: "<200")
+                ]
             )
+        ]
+
+        var body: some View {
+            VStack {
+                BloodTestsSection(
+                    bloodTests: $sampleTests,
+                    onAddNew: {},
+                    onEdit: { _ in },
+                    onDelete: { _ in }
+                )
+
+                BloodTestsSection(
+                    bloodTests: .constant([]),
+                    onAddNew: {},
+                    onEdit: { _ in },
+                    onDelete: { _ in }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow editing existing blood tests by reusing entry view and preserving IDs
- add deletion for entire blood test results and individual test items
- wire up edit and delete actions in health data list and detail screens

## Testing
- `xcodebuild -scheme HealthApp -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build` (fails: command not found)
- `xcodebuild test -scheme HealthApp -destination 'platform=iOS Simulator,name=iPhone 16 Pro'` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c80afc698483319b664cfc606960ff