### PR TITLE
fix: restore lab import review in on-device fallback path

### DIFF
--- a/HealthApp/HealthApp/Services/DocumentProcessor.swift
+++ b/HealthApp/HealthApp/Services/DocumentProcessor.swift
@@ -594,16 +594,22 @@ class DocumentProcessor: ObservableObject {
         let healthDataItems = result.healthDataItems
         AppLog.shared.documents("Found \(healthDataItems.count) structured health data items")
 
+        // Filter to lab-relevant items only to avoid importing non-lab data (vitals, demographics, etc.)
+        // as blood test results if the AI mapping fails during fallback
+        let nonLabTypes: Set<String> = ["Personal Information", "Demographics", "Vital Signs", "Imaging", "Radiology"]
+        let labOnlyItems = healthDataItems.filter { !nonLabTypes.contains($0.type) }
+        AppLog.shared.documents("Filtered to \(labOnlyItems.count) lab-specific items for blood test extraction")
+
         // Only extract blood tests for lab reports (or uncategorized documents for backward compatibility)
         let isLabReport = document.documentCategory == .labReport || document.documentCategory == .other
-        
+
         // Primary approach: Use full document text for AI-powered blood test extraction (only for lab reports)
         if isLabReport && !result.extractedText.isEmpty {
             AppLog.shared.documents("Attempting blood test extraction from full document text (lab report)")
             do {
                 let bloodTest = try await createBloodTestResultFromText(
                     documentText: result.extractedText,
-                    extractedItems: healthDataItems, // Use structured items as fallback if mapping fails
+                    extractedItems: labOnlyItems, // Lab-only items as safe fallback if AI text mapping fails
                     document: document
                 )
                 extractedData.append(try AnyHealthData(bloodTest))

--- a/HealthApp/HealthApp/Services/DocumentProcessor.swift
+++ b/HealthApp/HealthApp/Services/DocumentProcessor.swift
@@ -590,6 +590,10 @@ class DocumentProcessor: ObservableObject {
 
         AppLog.shared.documents("Starting health data extraction -- text: \(result.extractedText.count) chars, category: \(document.documentCategory.displayName)")
 
+        // Parse structured data once so we can use it as fallback context for blood test extraction
+        let healthDataItems = result.healthDataItems
+        AppLog.shared.documents("Found \(healthDataItems.count) structured health data items")
+
         // Only extract blood tests for lab reports (or uncategorized documents for backward compatibility)
         let isLabReport = document.documentCategory == .labReport || document.documentCategory == .other
         
@@ -599,7 +603,7 @@ class DocumentProcessor: ObservableObject {
             do {
                 let bloodTest = try await createBloodTestResultFromText(
                     documentText: result.extractedText,
-                    extractedItems: [], // We'll use only the text
+                    extractedItems: healthDataItems, // Use structured items as fallback if mapping fails
                     document: document
                 )
                 extractedData.append(try AnyHealthData(bloodTest))
@@ -613,8 +617,6 @@ class DocumentProcessor: ObservableObject {
         }
 
         // Fallback approach: Parse structured data if available (for other data types)
-        let healthDataItems = result.healthDataItems
-        AppLog.shared.documents("Found \(healthDataItems.count) structured health data items")
 
         if !healthDataItems.isEmpty {
             // Group health data items by type and create appropriate health data objects
@@ -810,15 +812,40 @@ class DocumentProcessor: ObservableObject {
             AppLog.shared.documents("AI mapping completed with \(mappingResult.confidence)% confidence")
             AppLog.shared.documents("Mapped \(mappingResult.bloodTestResult.results.count) lab values")
 
+            // Force review for all imports (same behavior as full-text path)
+            var finalBloodTest = mappingResult.bloodTestResult
+            if mappingResult.needsReview {
+                AppLog.shared.documents("Found \(mappingResult.importGroups.count) groups requiring review", level: .warning)
+
+                let pendingReview = PendingImportReview(
+                    documentId: document.id,
+                    documentName: document.fileName,
+                    importGroups: mappingResult.importGroups,
+                    bloodTestResult: finalBloodTest
+                )
+
+                await MainActor.run {
+                    self.pendingImportReview = pendingReview
+                }
+
+                AppLog.shared.documents("Set pending import review from item-based mapping - UI should show review sheet")
+
+                var reviewMetadata = finalBloodTest.metadata ?? [:]
+                reviewMetadata["needs_review"] = "true"
+                reviewMetadata["import_groups_count"] = String(mappingResult.importGroups.count)
+                reviewMetadata["pending_review"] = "true"
+                finalBloodTest.metadata = reviewMetadata
+            }
+
             // Add additional metadata
-            var enhancedMetadata = mappingResult.bloodTestResult.metadata ?? [:]
+            var enhancedMetadata = finalBloodTest.metadata ?? [:]
             enhancedMetadata["source_document_id"] = document.id.uuidString
             enhancedMetadata["document_filename"] = document.fileName
             enhancedMetadata["processing_method"] = "ai_powered_mapping"
             enhancedMetadata["raw_items_count"] = String(items.count)
 
             // Create enhanced blood test result
-            var enhancedBloodTest = mappingResult.bloodTestResult
+            var enhancedBloodTest = finalBloodTest
             enhancedBloodTest.metadata = enhancedMetadata
 
             return enhancedBloodTest


### PR DESCRIPTION
### Motivation
- The on-device document processing path could fall back to a placeholder blood test without providing reviewable candidates, causing the UI review/accept flow to never appear for on-device imports.
- The intent is to ensure the item-based (on-device) mapping path has the same review behavior and metadata as the full-text AI mapping path so users can review and accept parsed lab values.

### Description
- Parse and expose structured `healthDataItems` early from `ProcessedDocumentResult` and pass them into `createBloodTestResultFromText` so the item-based fallback mapping has real context instead of an empty list (file: `Services/DocumentProcessor.swift`).
- In the AI mapping from items path, create a `PendingImportReview` and assign it to `pendingImportReview` on the `MainActor` when `mappingResult.needsReview` so the UI review sheet is triggered the same way as the full-text path.
- Persist the review-related metadata keys (`needs_review`, `import_groups_count`, `pending_review`) onto the `BloodTestResult` metadata and unify creation of the enhanced blood test result so downstream UI/DB logic can detect pending reviews.

### Testing
- No automated unit or UI tests were executed for this patch (per repo guidance to avoid `xcodebuild` unless explicitly requested).
- Changes were validated via targeted source inspection and diffs to ensure the new branches and metadata assignments are present in `Services/DocumentProcessor.swift` and align with the full-text mapping behavior; CI should run the full build and XCTest to verify runtime integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfad84e3f88331a0fa9814bfee8a83)