### PR TITLE
fix: show real storage metrics in Storage Usage screen

### DIFF
--- a/HealthApp/HealthApp/Database/DatabaseManager+Chat.swift
+++ b/HealthApp/HealthApp/Database/DatabaseManager+Chat.swift
@@ -248,32 +248,38 @@ extension DatabaseManager {
     // MARK: - Chat Statistics
     func getChatStatistics() async throws -> ChatStatistics {
         guard let db = db else { throw DatabaseError.connectionFailed }
-        
-        let totalConversations = try db.scalar(chatConversationsTable.count)
-        let totalMessages = try db.scalar(chatMessagesTable.count)
-        
-        // Get total tokens used
-        let totalTokens: Int = try db.scalar(chatMessagesTable.select(messageTokens.sum)) ?? 0
-        
-        // Get average response time
-        let avgResponseTime: Double = try db.scalar(chatMessagesTable
-            .filter(messageRole == MessageRole.assistant.rawValue && messageProcessingTime != nil)
-            .select(messageProcessingTime.average)) ?? 0.0
-        
-        // Get last chat date
-        let lastChatTimestamp: Int64? = try db.scalar(chatConversationsTable.select(conversationUpdatedAt.max))
-        let lastChatDate = lastChatTimestamp.map { Date(timeIntervalSince1970: TimeInterval($0)) }
-        
-        return ChatStatistics(
-            totalConversations: totalConversations,
-            totalMessages: totalMessages,
-            totalTokensUsed: totalTokens,
-            averageResponseTime: avgResponseTime,
-            mostUsedDataTypes: [], // TODO: Implement this calculation
-            lastChatDate: lastChatDate
-        )
+        let conversationsTable = chatConversationsTable
+        let messagesTable = chatMessagesTable
+        let tokensExpr = messageTokens
+        let roleExpr = messageRole
+        let processingTimeExpr = messageProcessingTime
+        let updatedAtExpr = conversationUpdatedAt
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                do {
+                    let totalConversations = try db.scalar(conversationsTable.count)
+                    let totalMessages = try db.scalar(messagesTable.count)
+                    let totalTokens: Int = try db.scalar(messagesTable.select(tokensExpr.sum)) ?? 0
+                    let avgResponseTime: Double = try db.scalar(messagesTable
+                        .filter(roleExpr == MessageRole.assistant.rawValue && processingTimeExpr != nil)
+                        .select(processingTimeExpr.average)) ?? 0.0
+                    let lastChatTimestamp: Int64? = try db.scalar(conversationsTable.select(updatedAtExpr.max))
+                    let lastChatDate = lastChatTimestamp.map { Date(timeIntervalSince1970: TimeInterval($0)) }
+                    continuation.resume(returning: ChatStatistics(
+                        totalConversations: totalConversations,
+                        totalMessages: totalMessages,
+                        totalTokensUsed: totalTokens,
+                        averageResponseTime: avgResponseTime,
+                        mostUsedDataTypes: [], // TODO: Implement this calculation
+                        lastChatDate: lastChatDate
+                    ))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
-    
+
     // MARK: - Helper Methods
     private func buildChatConversation(from row: Row) async throws -> ChatConversation {
         let id = UUID(uuidString: row[conversationId]) ?? UUID()

--- a/HealthApp/HealthApp/Database/DatabaseManager+Documents.swift
+++ b/HealthApp/HealthApp/Database/DatabaseManager+Documents.swift
@@ -274,8 +274,16 @@ extension DatabaseManager {
     // MARK: - Document Statistics
     func getDocumentCount() async throws -> Int {
         guard let db = db else { throw DatabaseError.connectionFailed }
-        
-        return try db.scalar(documentsTable.count)
+        let table = documentsTable
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                do {
+                    continuation.resume(returning: try db.scalar(table.count))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
     
     func getDocumentCount(for status: ProcessingStatus) async throws -> Int {

--- a/HealthApp/HealthApp/Database/DatabaseManager.swift
+++ b/HealthApp/HealthApp/Database/DatabaseManager.swift
@@ -639,16 +639,30 @@ class DatabaseManager: ObservableObject {
     // MARK: - Storage Estimates
     func getHealthDataPayloadSizeEstimate() async throws -> Int64 {
         guard let db = db else { throw DatabaseError.connectionFailed }
-
-        let result = try db.scalar("SELECT COALESCE(SUM(LENGTH(encrypted_data)), 0) FROM health_data")
-        return result as? Int64 ?? 0
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                do {
+                    let result = try db.scalar("SELECT COALESCE(SUM(LENGTH(encrypted_data)), 0) FROM health_data")
+                    continuation.resume(returning: result as? Int64 ?? 0)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 
     func getChatPayloadSizeEstimate() async throws -> Int64 {
         guard let db = db else { throw DatabaseError.connectionFailed }
-
-        let result = try db.scalar("SELECT COALESCE(SUM(LENGTH(content)), 0) FROM chat_messages")
-        return result as? Int64 ?? 0
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                do {
+                    let result = try db.scalar("SELECT COALESCE(SUM(LENGTH(content)), 0) FROM chat_messages")
+                    continuation.resume(returning: result as? Int64 ?? 0)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 }
 

--- a/HealthApp/HealthApp/Database/DatabaseManager.swift
+++ b/HealthApp/HealthApp/Database/DatabaseManager.swift
@@ -635,6 +635,21 @@ class DatabaseManager: ObservableObject {
         let decryptedData = try AES.GCM.open(sealedBox, using: encryptionKey)
         return String(data: decryptedData, encoding: .utf8) ?? ""
     }
+
+    // MARK: - Storage Estimates
+    func getHealthDataPayloadSizeEstimate() async throws -> Int64 {
+        guard let db = db else { throw DatabaseError.connectionFailed }
+
+        let result = try db.scalar("SELECT COALESCE(SUM(LENGTH(encrypted_data)), 0) FROM health_data")
+        return result as? Int64 ?? 0
+    }
+
+    func getChatPayloadSizeEstimate() async throws -> Int64 {
+        guard let db = db else { throw DatabaseError.connectionFailed }
+
+        let result = try db.scalar("SELECT COALESCE(SUM(LENGTH(content)), 0) FROM chat_messages")
+        return result as? Int64 ?? 0
+    }
 }
 
 // MARK: - Database Errors

--- a/HealthApp/HealthApp/Utils/FileSystemManager.swift
+++ b/HealthApp/HealthApp/Utils/FileSystemManager.swift
@@ -492,60 +492,47 @@ class FileSystemManager: ObservableObject {
     
     // MARK: - Storage Usage
     func getStorageUsage() async throws -> FileSystemStorageUsage {
-        let fileManager = FileManager.default
-        var totalSize: Int64 = 0
-        var documentSize: Int64 = 0
-        var thumbnailSize: Int64 = 0
-        var exportSize: Int64 = 0
-        var logSize: Int64 = 0
-        
-        // Calculate documents size
-        let documentContents = try fileManager.contentsOfDirectory(at: documentsDirectory, 
-                                                                   includingPropertiesForKeys: [.fileSizeKey])
-        for documentURL in documentContents {
-            let resourceValues = try documentURL.resourceValues(forKeys: [.fileSizeKey])
-            let size = Int64(resourceValues.fileSize ?? 0)
-            documentSize += size
-            totalSize += size
+        let docsDir = documentsDirectory
+        let thumbsDir = thumbnailsDirectory
+        let exportsDir = exportsDirectory
+        let logsDir = logsDirectory
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                do {
+                    let fileManager = FileManager.default
+                    var totalSize: Int64 = 0
+                    var documentSize: Int64 = 0
+                    var thumbnailSize: Int64 = 0
+                    var exportSize: Int64 = 0
+                    var logSize: Int64 = 0
+
+                    func dirSize(_ url: URL) throws -> Int64 {
+                        var size: Int64 = 0
+                        let contents = try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: [.fileSizeKey])
+                        for fileURL in contents {
+                            size += Int64(try fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0)
+                        }
+                        return size
+                    }
+
+                    documentSize = try dirSize(docsDir)
+                    thumbnailSize = try dirSize(thumbsDir)
+                    exportSize = try dirSize(exportsDir)
+                    logSize = try dirSize(logsDir)
+                    totalSize = documentSize + thumbnailSize + exportSize + logSize
+
+                    continuation.resume(returning: FileSystemStorageUsage(
+                        totalSize: totalSize,
+                        documentsSize: documentSize,
+                        thumbnailsSize: thumbnailSize,
+                        exportsSize: exportSize,
+                        logsSize: logSize
+                    ))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
         }
-        
-        // Calculate thumbnails size
-        let thumbnailContents = try fileManager.contentsOfDirectory(at: thumbnailsDirectory, 
-                                                                    includingPropertiesForKeys: [.fileSizeKey])
-        for thumbnailURL in thumbnailContents {
-            let resourceValues = try thumbnailURL.resourceValues(forKeys: [.fileSizeKey])
-            let size = Int64(resourceValues.fileSize ?? 0)
-            thumbnailSize += size
-            totalSize += size
-        }
-        
-        // Calculate exports size
-        let exportContents = try fileManager.contentsOfDirectory(at: exportsDirectory, 
-                                                                 includingPropertiesForKeys: [.fileSizeKey])
-        for exportURL in exportContents {
-            let resourceValues = try exportURL.resourceValues(forKeys: [.fileSizeKey])
-            let size = Int64(resourceValues.fileSize ?? 0)
-            exportSize += size
-            totalSize += size
-        }
-        
-        // Calculate logs size
-        let logContents = try fileManager.contentsOfDirectory(at: logsDirectory, 
-                                                              includingPropertiesForKeys: [.fileSizeKey])
-        for logURL in logContents {
-            let resourceValues = try logURL.resourceValues(forKeys: [.fileSizeKey])
-            let size = Int64(resourceValues.fileSize ?? 0)
-            logSize += size
-            totalSize += size
-        }
-        
-        return FileSystemStorageUsage(
-            totalSize: totalSize,
-            documentsSize: documentSize,
-            thumbnailsSize: thumbnailSize,
-            exportsSize: exportSize,
-            logsSize: logSize
-        )
     }
     
     // MARK: - Encryption/Decryption

--- a/HealthApp/HealthApp/Views/StorageUsageView.swift
+++ b/HealthApp/HealthApp/Views/StorageUsageView.swift
@@ -19,9 +19,18 @@ struct StorageUsageView: View {
                 }
             } else if let lastErrorMessage {
                 Section {
-                    Text(lastErrorMessage)
-                        .font(.footnote)
-                        .foregroundColor(.secondary)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(lastErrorMessage)
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .accessibilityLabel(lastErrorMessage)
+                        Button("Retry") {
+                            Task { await loadStorageInfo() }
+                        }
+                        .accessibilityLabel("Retry loading storage information")
+                        .accessibilityHint("Attempts to reload storage usage data")
+                        .accessibilityIdentifier("retryStorageLoadButton")
+                    }
                 }
             } else {
                 Section("Storage Overview") {

--- a/HealthApp/HealthApp/Views/StorageUsageView.swift
+++ b/HealthApp/HealthApp/Views/StorageUsageView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct StorageUsageView: View {
     @State private var storageInfo = StorageInfo()
     @State private var isLoading = true
+    @State private var lastErrorMessage: String?
     
     var body: some View {
         List {
@@ -15,6 +16,12 @@ struct StorageUsageView: View {
                             .foregroundColor(.secondary)
                     }
                     .padding(.vertical, 8)
+                }
+            } else if let lastErrorMessage {
+                Section {
+                    Text(lastErrorMessage)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
                 }
             } else {
                 Section("Storage Overview") {
@@ -106,21 +113,36 @@ struct StorageUsageView: View {
     
     private func loadStorageInfo() async {
         isLoading = true
-        
-        // Simulate loading storage information
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
-        
-        // Mock storage data
-        storageInfo = StorageInfo(
-            healthDataSize: 1_024_000,      // 1 MB
-            documentsSize: 15_728_640,      // 15 MB
-            thumbnailsSize: 2_097_152,      // 2 MB
-            chatHistorySize: 512_000,       // 512 KB
-            cacheSize: 1_048_576,           // 1 MB
-            documentCount: 25,
-            conversationCount: 8
-        )
-        
+        lastErrorMessage = nil
+
+        do {
+            async let fileSystemUsage = FileSystemManager.shared.getStorageUsage()
+            async let documentCount = DatabaseManager.shared.getDocumentCount()
+            async let chatStats = DatabaseManager.shared.getChatStatistics()
+            async let healthDataPayloadSize = DatabaseManager.shared.getHealthDataPayloadSizeEstimate()
+            async let chatPayloadSize = DatabaseManager.shared.getChatPayloadSizeEstimate()
+
+            let usage = try await fileSystemUsage
+            let docs = try await documentCount
+            let chats = try await chatStats
+            let healthSize = try await healthDataPayloadSize
+            let chatSize = try await chatPayloadSize
+
+            storageInfo = StorageInfo(
+                healthDataSize: healthSize,
+                documentsSize: usage.documentsSize,
+                thumbnailsSize: usage.thumbnailsSize,
+                chatHistorySize: chatSize,
+                cacheSize: usage.exportsSize + usage.logsSize,
+                documentCount: docs,
+                conversationCount: chats.totalConversations
+            )
+        } catch {
+            storageInfo = StorageInfo()
+            lastErrorMessage = "Unable to load storage details right now."
+            AppLog.shared.ui("Failed to load storage usage: \(error)", level: .error)
+        }
+
         isLoading = false
     }
     


### PR DESCRIPTION
### Motivation
- The Storage Usage screen used hard-coded mock values (including a fixed "25 documents") which could mislead users when the Documents tab was actually empty. 
- Update the storage screen to report live on-device metrics so storage diagnostics reflect the real state of the app.

### Description
- Replaced simulated storage data and artificial delay in `StorageUsageView` with real metrics fetched from `FileSystemManager` and `DatabaseManager`, and added a lightweight error UI to surface load failures (`HealthApp/HealthApp/Views/StorageUsageView.swift`).
- Added two new helper methods to `DatabaseManager` to estimate payload sizes for health data and chat messages (`getHealthDataPayloadSizeEstimate()` and `getChatPayloadSizeEstimate()`) used by the storage screen (`HealthApp/HealthApp/Database/DatabaseManager.swift`).
- Combined file-system size (documents/thumbnails/exports/logs), document count, conversation count, and payload size estimates into the `StorageInfo` model so the UI shows a real breakdown instead of placeholders.
- Added error handling and logging so failures produce a friendly message in the Storage screen and an error entry in the app log instead of showing static numbers.

### Testing
- Ran `git diff --check` to validate there are no trivial formatting or whitespace issues and it passed. 
- Performed automated repository searches to verify the mocked literals and the simulated `Task.sleep` were removed from `StorageUsageView`, and those checks succeeded.
- No unit or UI test suite run was requested during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb478caf8833185c2367d7b397023)