### PR TITLE
fix: align HealthKit sleep aggregation with Apple Health totals

### DIFF
--- a/HealthApp/HealthApp/Managers/HealthKitManager.swift
+++ b/HealthApp/HealthApp/Managers/HealthKitManager.swift
@@ -642,29 +642,34 @@ class HealthKitManager: ObservableObject {
         return totalMinutes > 0 ? totalMinutes : nil
     }
 
+    // MARK: - Private Helpers
+
     private func calculateUnionMinutes(samples: [HKCategorySample]) -> Int {
         guard !samples.isEmpty else { return 0 }
 
         let sortedIntervals = samples
-            .map { ($0.startDate, $0.endDate) }
-            .sorted { $0.0 < $1.0 }
+            .compactMap { sample -> (start: Date, end: Date)? in
+                guard sample.startDate <= sample.endDate else { return nil }
+                return (start: sample.startDate, end: sample.endDate)
+            }
+            .sorted { $0.start < $1.start }
 
-        var merged: [(Date, Date)] = []
+        var merged: [(start: Date, end: Date)] = []
         for interval in sortedIntervals {
             guard let last = merged.last else {
                 merged.append(interval)
                 continue
             }
 
-            if interval.0 <= last.1 {
-                merged[merged.count - 1] = (last.0, max(last.1, interval.1))
+            if interval.start <= last.end {
+                merged[merged.count - 1] = (last.start, max(last.end, interval.end))
             } else {
                 merged.append(interval)
             }
         }
 
         let totalSeconds = merged.reduce(0.0) { total, interval in
-            total + interval.1.timeIntervalSince(interval.0)
+            total + interval.end.timeIntervalSince(interval.start)
         }
 
         return Int(totalSeconds / secondsPerMinute)

--- a/HealthApp/HealthApp/Managers/HealthKitManager.swift
+++ b/HealthApp/HealthApp/Managers/HealthKitManager.swift
@@ -553,10 +553,11 @@ class HealthKitManager: ObservableObject {
             healthStore.execute(query)
         }
 
-        // Group sleep samples by date
+        // Group sleep samples by "sleep night" using endDate.
+        // Apple Health's nightly totals are anchored to when the sleep session ends
+        // (e.g., sleep from 11 PM to 7 AM belongs to the morning's date).
         let groupedSleep = Dictionary(grouping: samples) { sample -> Date in
-            let calendar = Calendar.current
-            return calendar.startOfDay(for: sample.startDate)
+            Calendar.current.startOfDay(for: sample.endDate)
         }
 
         // Convert to SleepData, taking the most recent 'limit' nights
@@ -577,11 +578,9 @@ class HealthKitManager: ObservableObject {
 
             guard !sleepSamples.isEmpty else { continue }
 
-            // Calculate total sleep time
-            let totalSleepSeconds = sleepSamples.reduce(0) { total, sample in
-                total + sample.endDate.timeIntervalSince(sample.startDate)
-            }
-            let totalSleepMinutes = Int(totalSleepSeconds / secondsPerMinute)
+            // Calculate total sleep time using union of intervals to avoid double-counting
+            // overlapping samples from multiple data sources.
+            let totalSleepMinutes = calculateUnionMinutes(samples: sleepSamples)
 
             // Get start and end times
             let startTime = sleepSamples.map { $0.startDate }.min() ?? date
@@ -615,10 +614,7 @@ class HealthKitManager: ObservableObject {
                 }
             }
 
-            let inBedSeconds = inBedSamples.reduce(0) { total, sample in
-                total + sample.endDate.timeIntervalSince(sample.startDate)
-            }
-            let inBedMinutes = Int(inBedSeconds / secondsPerMinute)
+            let inBedMinutes = calculateUnionMinutes(samples: inBedSamples)
 
             sleepDataArray.append(SleepData(
                 date: date,
@@ -642,9 +638,35 @@ class HealthKitManager: ObservableObject {
         let stageSamples = samples.filter { $0.value == stage.rawValue }
         guard !stageSamples.isEmpty else { return nil }
 
-        let totalSeconds = stageSamples.reduce(0) { total, sample in
-            total + sample.endDate.timeIntervalSince(sample.startDate)
+        let totalMinutes = calculateUnionMinutes(samples: stageSamples)
+        return totalMinutes > 0 ? totalMinutes : nil
+    }
+
+    private func calculateUnionMinutes(samples: [HKCategorySample]) -> Int {
+        guard !samples.isEmpty else { return 0 }
+
+        let sortedIntervals = samples
+            .map { ($0.startDate, $0.endDate) }
+            .sorted { $0.0 < $1.0 }
+
+        var merged: [(Date, Date)] = []
+        for interval in sortedIntervals {
+            guard let last = merged.last else {
+                merged.append(interval)
+                continue
+            }
+
+            if interval.0 <= last.1 {
+                merged[merged.count - 1] = (last.0, max(last.1, interval.1))
+            } else {
+                merged.append(interval)
+            }
         }
+
+        let totalSeconds = merged.reduce(0.0) { total, interval in
+            total + interval.1.timeIntervalSince(interval.0)
+        }
+
         return Int(totalSeconds / secondsPerMinute)
     }
 


### PR DESCRIPTION
### Motivation
- Apple Health anchors nightly sleep summaries to the sleep session end (wake-day) and HealthKit samples can overlap, causing inflated or misattributed totals.
- The existing logic grouped by `startDate` and summed raw sample durations, which can double-count overlapping intervals and split overnight sessions across two dates.

### Description
- Changed sleep-night grouping to anchor by each sample's `endDate` so overnight sessions map to the same date Apple Health uses, in `HealthApp/HealthApp/Managers/HealthKitManager.swift`.
- Replaced naive duration summation with a union/merge of sample intervals to compute totals without double-counting by adding a helper `calculateUnionMinutes(samples:)` and using it for total sleep and in‑bed time.
- Applied the union-based computation to iOS 16+ sleep stage calculations (`deep`, `REM`, `core`, `awake`) so stage totals are consistent with merged intervals.
- Preserved start/end time selection from the earliest start and latest end of the relevant samples while setting `source: .appleHealth` for produced `SleepData` entries.

### Testing
- No automated build or test runs were executed for this change (per repository guideline `DO NOT run xcodebuild` unless explicitly requested).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4173309883318d189cf644921a28)