### PR TITLE
docs: Cursor Cloud Linux development environment guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,54 @@ Note: Our default Simulator target is `iPhone 16 Pro`. If that runtime isn't ins
 - Do not commit secrets or PHI. Data is local and encrypted; follow patterns in `Services/` and `Database` usage.
 - Network calls must use TLS and validate responses (see `OllamaClient.swift`, `DoclingClient.swift`).
 - For AI integration details, see `HealthApp/OLLAMA_SWIFT_INTEGRATION.md`.
+
+## Cursor Cloud specific instructions
+
+This repository is an **iOS/Xcode** project. Cursor Cloud VMs are **Linux** and cannot run `xcodebuild`, the iOS Simulator, or the SwiftUI app binary. Use the VM for Swift edits, static analysis, and optional **Ollama** (default AI backend) smoke tests; run full builds/tests on a Mac with Xcode 15+.
+
+### What works on Linux (this VM)
+
+| Task | Command / notes |
+|------|-----------------|
+| SwiftLint (style/static checks) | `cd HealthApp && swiftlint lint` — expects `swiftlint` on `PATH` (default rules; repo has no `.swiftlint.yml`) |
+| Ollama API (matches `OllamaClient` / port `11434`) | Start server, then call HTTP API (see below) |
+| Personas prompts sanity | `ls Personas-Prompts/*.txt` — static `.txt` files bundled for chat personas |
+| Git / docs / code review | Standard |
+
+### What requires macOS
+
+| Task | Command |
+|------|---------|
+| Build app | `cd HealthApp && xcodebuild -scheme HealthApp -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build` |
+| Unit/UI tests | `xcodebuild test -scheme HealthApp -destination 'platform=iOS Simulator,name=iPhone 16 Pro'` |
+| SwiftPM resolve for app | Xcode first open / `xcodebuild -resolvePackageDependencies` on Mac |
+
+### Ollama on the Cloud VM
+
+The app defaults to `localhost:11434` (`ServerConfigurationConstants`). On Linux, run the server in **tmux** (long-lived):
+
+```bash
+SESSION_NAME="ollama-server"
+tmux -f /exec-daemon/tmux.portal.conf has-session -t "=$SESSION_NAME" 2>/dev/null \
+  || tmux -f /exec-daemon/tmux.portal.conf new-session -d -s "$SESSION_NAME" -- "${SHELL:-bash}" -l
+tmux -f /exec-daemon/tmux.portal.conf send-keys -t "$SESSION_NAME:0.0" 'ollama serve' C-m
+```
+
+Smoke test (connection + chat), same API the app uses:
+
+```bash
+curl -s http://127.0.0.1:11434/api/tags
+curl -s http://127.0.0.1:11434/api/chat -d '{"model":"tinyllama","messages":[{"role":"user","content":"Hello from BisonHealth AI setup"}],"stream":false}'
+```
+
+Pull a model once per VM if needed: `ollama pull tinyllama` (or `llama3.2` to match app default). **Docling** (`localhost:5001`) is optional — default document processing is on-device; no Docling container is defined in-repo.
+
+### Mac + Linux VM workflow
+
+Develop on Linux, run the app on a Mac Simulator/device. Point **Settings → Ollama** at `http://<cloud-vm-host>:11434` when testing AI against the VM-hosted Ollama instance.
+
+### Tooling paths (VM image)
+
+- Swift: `/opt/swift/usr/bin` (add to `PATH` in shell profile if missing)
+- SwiftLint: `/usr/local/bin/swiftlint`
+- Ollama: `ollama` / `ollama serve` (system install under `/usr/local`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents how to develop BisonHealth AI on **Cursor Cloud Linux VMs**, where the iOS app cannot be built or run. Covers SwiftLint static analysis, optional Ollama backend smoke tests, and macOS-only `xcodebuild` requirements.

## Environment verified on Linux VM

- **SwiftLint** `0.57.0` — lints `HealthApp/` Swift sources (5092 existing style warnings; no new code changes)
- **Ollama** on `127.0.0.1:11434` — `/api/tags` and `/api/chat` hello-world successful (`tinyllama`)
- **Swift** `6.0.3` toolchain installed at `/opt/swift`
- **xcodebuild** — not available on Linux (expected); full build/test requires macOS + Xcode 15+

## VM startup

Update script is a no-op (`true`) — no root lockfiles in this repo; SwiftPM resolves on Mac via Xcode.

## Privacy

Documentation only; no PHI or secrets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79a769ac-ca31-4eb6-97ed-5b848d819f92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a769ac-ca31-4eb6-97ed-5b848d819f92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

