### PR TITLE
fix: resolve ChatSession sending violations under Swift 6

### DIFF
--- a/HealthApp/HealthApp/MLXOnDeviceLLM/MLXOnDeviceClient.swift
+++ b/HealthApp/HealthApp/MLXOnDeviceLLM/MLXOnDeviceClient.swift
@@ -174,7 +174,7 @@ class MLXOnDeviceClient: ObservableObject, AIProviderInterface {
             let session = try makeIsolatedSession(maxTokensOverride: 10)
 
             // Quick test: generate a short response
-            let testResult = try await session.respond(to: "Say OK")
+            let testResult = try await collectResponse(from: session, to: "Say OK")
 
             let success = !testResult.isEmpty
             connectionStatus = success ? .connected : .error(MLXOnDeviceError.generationFailed("Empty test response"))
@@ -203,7 +203,7 @@ class MLXOnDeviceClient: ObservableObject, AIProviderInterface {
 
         let startTime = Date()
 
-        let response = try await session.respond(to: message)
+        let response = try await collectResponse(from: session, to: message)
         let responseTime = Date().timeIntervalSince(startTime)
 
         return MLXOnDeviceResponse(
@@ -522,6 +522,25 @@ class MLXOnDeviceClient: ObservableObject, AIProviderInterface {
         )
     }
 
+    /// Collect a full response from a session.
+    ///
+    /// `ChatSession.respond(to:)` is a nonisolated `async` method, so calling it
+    /// from this `@MainActor` type would send the main-actor-isolated,
+    /// non-`Sendable` session across an isolation boundary. `streamResponse` is
+    /// synchronous — it only hands `Sendable` state to its own internal task —
+    /// so accumulating its chunks here is the isolation-safe equivalent.
+    private func collectResponse(
+        from session: ChatSession,
+        to prompt: String,
+        image: UserInput.Image? = nil
+    ) async throws -> String {
+        var output = ""
+        for try await chunk in session.streamResponse(to: prompt, image: image) {
+            output += chunk
+        }
+        return output
+    }
+
     private func makeChatHistory(from conversationHistory: [ChatMessage]) -> [Chat.Message] {
         conversationHistory.compactMap { message in
             switch message.role {
@@ -609,7 +628,11 @@ extension MLXOnDeviceClient: VisionDocumentExtractor {
 
                 let pagePrompt = Self.compactVisionExtractionPrompt(pageNumber: page.pageNumber)
 
-                let response = try await session.respond(to: pagePrompt, image: .ciImage(ciImage))
+                let response = try await collectResponse(
+                    from: session,
+                    to: pagePrompt,
+                    image: .ciImage(ciImage)
+                )
                 let parsedCount = mergePageJSON(
                     response,
                     pageNumber: page.pageNumber,


### PR DESCRIPTION
## What changed

Three `ChatSession.respond(to:)` call sites in `MLXOnDeviceClient` now route through a new private `collectResponse(from:to:image:)` helper that accumulates chunks from `streamResponse(to:)`.

Call sites updated:
- `testConnection()`
- `sendMessage(_:context:)`
- `extractFromDocument(...)` per-page VLM extraction

## Why

The build failed under Swift 6 strict concurrency with `Sending 'session' risks causing data races` at all three sites.

`ChatSession` is a plain non-`Sendable` `final class`, and `respond(to:)` is a `nonisolated async` method. Calling it from `MLXOnDeviceClient` (a `@MainActor` class) hops off the main actor, which requires *sending* the main-actor-isolated session across an isolation boundary — not allowed.

`streamResponse(to:)` is **synchronous**. It returns an `AsyncThrowingStream` and internally spawns its own `Task` capturing only `Sendable` fields (`model`, `instructions`, `processing`, `tools`, `toolDispatch`) plus a `SendableBox` for the message. The session itself never crosses an isolation boundary — which is why the existing streaming chat path in `sendStreamingChatMessage` already compiled cleanly.

## Notes for reviewers

- **Behavior is unchanged.** `ChatSession.respond` is implemented upstream as this exact loop over `streamResponse`, so the helper is a like-for-like substitution.
- **`MLXGPUGate` semantics preserved.** The accumulation loop stays inside the `defer`-scoped critical section, so the gate hold still spans the entire generation — including the per-page hold in document extraction.
- **Alternative considered:** marking `makeIsolatedSession` as returning `sending ChatSession` would also compile, but it hands the session to a nonisolated context. `ChatSession`'s own documentation states it is not thread-safe, so keeping it main-actor-resident and crossing the boundary only via the library's own `Sendable`-checked internals is the safer shape.
- **Verification:** `xcodebuild` for `generic/platform=iOS` — **BUILD SUCCEEDED**, no errors or new warnings. A device build is required here; this code is inside `#if !targetEnvironment(simulator)`, so a simulator build does not typecheck it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)